### PR TITLE
Reduce polling load for game endpoints

### DIFF
--- a/src/shared/lib/current-round-store.ts
+++ b/src/shared/lib/current-round-store.ts
@@ -5,7 +5,7 @@ import { useUserContext } from "@/shared/context/UserContext";
 import { getBackendHost } from "@/shared/lib/host";
 import type { CurrentRound } from "@/shared/types/current-round";
 
-const TTL_MS = 1500;
+const TTL_MS = 4000;
 
 type CacheState = {
     round: CurrentRound | null;
@@ -106,7 +106,7 @@ export function useCurrentRoundStore() {
             if (initData) headers["x-telegram-init-data"] = initData;
 
             const fetchPromise = fetch(
-                `https://${host}/api/game/current?_=${Date.now()}`,
+                `https://${host}/api/game/current`,
                 { cache: "no-store", headers }
             ).then(async (res) => {
                 if (!res.ok) throw new Error(`current round request failed ${res.status}`);

--- a/src/shared/lib/history-store.ts
+++ b/src/shared/lib/history-store.ts
@@ -1,0 +1,93 @@
+"use client";
+
+import { useCallback } from "react";
+import { getBackendHost } from "@/shared/lib/host";
+
+export type HistoryRow = { roundId: number; crashMultiplier: number; endTime: string };
+
+const TTL_MS = 4000;
+
+export type HistorySnapshot = {
+    history: HistoryRow[];
+    receivedAt: number;
+};
+
+type CacheState = {
+    history: HistoryRow[] | null;
+    receivedAt: number | null;
+    inflight: Promise<HistorySnapshot> | null;
+};
+
+const cache: CacheState = {
+    history: null,
+    receivedAt: null,
+    inflight: null
+};
+
+function shouldFetch(force: boolean): boolean {
+    if (force) return true;
+    if (!cache.history) return true;
+    if (cache.receivedAt === null) return true;
+    return Date.now() - cache.receivedAt > TTL_MS;
+}
+
+function updateCache(history: HistoryRow[], receivedAt: number) {
+    cache.history = history;
+    cache.receivedAt = receivedAt;
+}
+
+export function getCachedHistory(): HistoryRow[] | null {
+    return cache.history;
+}
+
+export function getCachedHistoryReceivedAt(): number | null {
+    return cache.receivedAt;
+}
+
+export function useHistoryStore() {
+    const host = getBackendHost();
+
+    const getHistory = useCallback(
+        async ({ force = false }: { force?: boolean } = {}): Promise<HistorySnapshot> => {
+            if (!shouldFetch(force) && cache.history && cache.receivedAt !== null) {
+                return { history: cache.history, receivedAt: cache.receivedAt };
+            }
+            if (cache.inflight) return cache.inflight;
+
+            const fetchPromise = fetch(`https://${host}/api/game/history`, {
+                cache: "no-store",
+                headers: { "Cache-Control": "no-cache", Pragma: "no-cache" }
+            }).then(async (res) => {
+                if (!res.ok) {
+                    throw new Error(`history request failed ${res.status}`);
+                }
+                const receivedAt = Date.now();
+                const data = await res.json();
+                const history = Array.isArray(data) ? (data as HistoryRow[]) : [];
+                updateCache(history, receivedAt);
+                return { history, receivedAt };
+            });
+
+            const finalPromise = fetchPromise.then(
+                (result) => {
+                    cache.inflight = null;
+                    return result;
+                },
+                (err) => {
+                    cache.inflight = null;
+                    throw err;
+                }
+            );
+
+            cache.inflight = finalPromise;
+            return finalPromise;
+        },
+        [host]
+    );
+
+    return {
+        getHistory,
+        history: cache.history,
+        receivedAt: cache.receivedAt
+    };
+}


### PR DESCRIPTION
## Summary
- increase the current round cache window and stop cache-busting query strings to lower `/api/game/current` polling frequency
- introduce a shared history store with request deduplication and TTL-based caching for `/api/game/history`
- switch the multipliers widget to the shared history store so repeated renders reuse cached data

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fd389541e883319c5d5faf6ca684d5