### PR TITLE
Stop polling bets count during running rounds

### DIFF
--- a/src/feature/players-list/conteiner/players-list.tsx
+++ b/src/feature/players-list/conteiner/players-list.tsx
@@ -11,7 +11,8 @@ export function PlayersList() {
     const roundId = state?.roundId ?? null;
     const initData = user?.initData ?? "";
     const useMock = process.env.NEXT_PUBLIC_USE_MOCK_BETS === "1";
-    const { totalBets, error } = (useMock ? useBetsNowMock : useBetsNowReal)(roundId, initData);
+    const betsEnabled = state?.phase !== "running";
+    const { totalBets, error } = (useMock ? useBetsNowMock : useBetsNowReal)(roundId, initData, { enabled: betsEnabled });
 
     return (
         <div className="mb-6">

--- a/src/shared/hooks/useBetsNowMock.ts
+++ b/src/shared/hooks/useBetsNowMock.ts
@@ -5,11 +5,16 @@ import type { RoundBet } from "./useBetsNow";
 
 const EMPTY_BETS: RoundBet[] = [];
 
-export function useBetsNowMock(roundId?: number | null, initData?: string) {
+type UseBetsNowMockOptions = {
+    enabled?: boolean;
+};
+
+export function useBetsNowMock(roundId?: number | null, initData?: string, options?: UseBetsNowMockOptions) {
     const [totalBets, setTotalBets] = useState(0);
     const error: Error | null = null;
 
     const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const enabled = options?.enabled ?? true;
 
     useEffect(() => {
         if (intervalRef.current) {
@@ -17,9 +22,23 @@ export function useBetsNowMock(roundId?: number | null, initData?: string) {
             intervalRef.current = null;
         }
 
+        if (!enabled) {
+            return () => {
+                if (intervalRef.current) {
+                    clearInterval(intervalRef.current);
+                    intervalRef.current = null;
+                }
+            };
+        }
+
         if (!roundId || !initData) {
             setTotalBets(0);
-            return;
+            return () => {
+                if (intervalRef.current) {
+                    clearInterval(intervalRef.current);
+                    intervalRef.current = null;
+                }
+            };
         }
 
         setTotalBets(0);
@@ -33,7 +52,7 @@ export function useBetsNowMock(roundId?: number | null, initData?: string) {
                 intervalRef.current = null;
             }
         };
-    }, [roundId, initData]);
+    }, [roundId, initData, enabled]);
 
     return { bets: EMPTY_BETS, totalBets, loading: false, error };
 }


### PR DESCRIPTION
## Summary
- add an `enabled` option to the live and mock `useBetsNow` hooks to pause polling when betting is unavailable
- update the players list container to disable bet count polling while a round is running

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fd7755e31c8331a85831b2301379e7