### PR TITLE
Restore players list bet details

### DIFF
--- a/src/feature/players-list/conteiner/players-list.tsx
+++ b/src/feature/players-list/conteiner/players-list.tsx
@@ -1,9 +1,13 @@
 
 import { Trans } from '@lingui/macro';
+import { Player } from "@/feature/players-list/ui/player";
 import { useUserContext } from "@/shared/context/UserContext";
 import { useGame } from "@/shared/hooks/useGame";
 import { useBetsNow as useBetsNowReal } from "@/shared/hooks/useBetsNow";
 import { useBetsNowMock } from "@/shared/hooks/useBetsNowMock";
+
+const maskUser = (userId: number, usernameMasked?: string) =>
+    usernameMasked?.trim() || `Игрок •••${String(userId).slice(-4).padStart(4, "0")}`;
 
 export function PlayersList() {
     const { user } = useUserContext();
@@ -11,15 +15,37 @@ export function PlayersList() {
     const roundId = state?.roundId ?? null;
     const initData = user?.initData ?? "";
     const useMock = process.env.NEXT_PUBLIC_USE_MOCK_BETS === "1";
-    const { totalBets, error } = (useMock ? useBetsNowMock : useBetsNowReal)(roundId, initData);
+    const betsEnabled = state?.phase !== "running";
+    const { bets, totalBets, loading, error } = (useMock ? useBetsNowMock : useBetsNowReal)(
+        roundId,
+        initData,
+        { enabled: betsEnabled },
+    );
+
+    const visibleBets = (bets.length > 0 ? bets : []).slice(0, 50);
 
     return (
-        <div className="mb-6">
+        <div className="space-y-3 mb-6">
             <div className="mt-4 text-[#969696] text-sm">
                 {error
                     ? <Trans>Не удалось загрузить ставки</Trans>
-                    : <Trans>Всего ставок: {totalBets}</Trans>}
+                    : loading
+                        ? <Trans>Загружаем ставки…</Trans>
+                        : <Trans>Всего ставок: {totalBets}</Trans>}
             </div>
+            {visibleBets.map(b => (
+                <Player
+                    key={b.betId}
+                    name={maskUser(b.userId, b.usernameMasked)}
+                    bet={b.amount}
+                    avatarUrl={b.avatarUrl}
+                />
+            ))}
+            {!loading && !error && bets.length === 0 && (
+                <div className="text-[#969696] text-sm text-center">
+                    <Trans>Пока нет ставок в этом раунде.</Trans>
+                </div>
+            )}
         </div>
     );
 }

--- a/src/shared/hooks/useBetsNow.ts
+++ b/src/shared/hooks/useBetsNow.ts
@@ -22,6 +22,41 @@ type BetsNowResponse = {
 
 const EMPTY_BETS: RoundBet[] = [];
 
+function isRoundBet(raw: unknown): raw is RoundBet {
+    if (!raw || typeof raw !== "object") return false;
+    const bet = raw as RoundBet;
+    return (
+        typeof bet.betId === "number" &&
+        typeof bet.userId === "number" &&
+        typeof bet.amount === "number" &&
+        typeof bet.multiplier === "number" &&
+        typeof bet.status === "string" &&
+        typeof bet.timestamp === "string"
+    );
+}
+
+function areBetsEqual(a: RoundBet[], b: RoundBet[]) {
+    if (a === b) return true;
+    if (a.length !== b.length) return false;
+    for (let i = 0; i < a.length; i += 1) {
+        const left = a[i];
+        const right = b[i];
+        if (
+            left.betId !== right.betId ||
+            left.userId !== right.userId ||
+            left.amount !== right.amount ||
+            left.multiplier !== right.multiplier ||
+            left.status !== right.status ||
+            left.timestamp !== right.timestamp ||
+            left.usernameMasked !== right.usernameMasked ||
+            left.avatarUrl !== right.avatarUrl
+        ) {
+            return false;
+        }
+    }
+    return true;
+}
+
 function extractBets(raw: unknown): unknown[] {
     if (Array.isArray(raw)) return raw;
     if (raw && typeof raw === "object" && Array.isArray((raw as BetsNowResponse).bets)) {
@@ -30,33 +65,89 @@ function extractBets(raw: unknown): unknown[] {
     return [];
 }
 
-export function useBetsNow(roundId?: number | null, initData?: string) {
+type UseBetsNowOptions = {
+    enabled?: boolean;
+};
+
+export function useBetsNow(roundId?: number | null, initData?: string, options?: UseBetsNowOptions) {
+    const [bets, setBets] = useState<RoundBet[]>(EMPTY_BETS);
     const [totalBets, setTotalBets] = useState(0);
+    const [loading, setLoading] = useState(false);
     const [error, setError] = useState<Error | null>(null);
     const host = getBackendHost();
     const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
     const totalRef = useRef(0);
+    const lastRoundRef = useRef<number | null>(null);
+    const lastInitDataRef = useRef<string | null>(null);
+    const hasFetchedRef = useRef(false);
+    const enabled = options?.enabled ?? true;
 
     useEffect(() => {
-        if (!roundId || !initData) {
-            totalRef.current = 0;
-            setTotalBets(prev => (prev === 0 ? prev : 0));
-            setError(prev => (prev ? null : prev));
+        let aborted = false;
+        let inFlight: AbortController | null = null;
+
+        const stopInterval = () => {
             if (intervalRef.current) {
                 clearInterval(intervalRef.current);
                 intervalRef.current = null;
             }
-            return;
+        };
+
+        const cleanup = () => {
+            aborted = true;
+            inFlight?.abort();
+            stopInterval();
+        };
+
+        const currentRoundId = roundId ?? null;
+        const lastRoundId = lastRoundRef.current;
+        const lastInitData = lastInitDataRef.current;
+        const currentInitData = initData ?? null;
+        const roundChanged = currentRoundId !== lastRoundId;
+        const initDataChanged = currentInitData !== lastInitData;
+
+        if (roundChanged) {
+            lastRoundRef.current = currentRoundId;
         }
-        totalRef.current = 0;
-        setTotalBets(prev => (prev === 0 ? prev : 0));
-        setError(prev => (prev ? null : prev));
-        let aborted = false;
-        let inFlight: AbortController | null = null;
+        if (initDataChanged) {
+            lastInitDataRef.current = currentInitData;
+        }
+
+        if (roundChanged || initDataChanged) {
+            totalRef.current = 0;
+            hasFetchedRef.current = false;
+            setBets(EMPTY_BETS);
+            setTotalBets(prev => (prev === 0 ? prev : 0));
+        }
+
+        if (!enabled) {
+            setLoading(false);
+            cleanup();
+            return cleanup;
+        }
+
+        if (!roundId || !initData) {
+            totalRef.current = 0;
+            hasFetchedRef.current = false;
+            setBets(EMPTY_BETS);
+            setTotalBets(prev => (prev === 0 ? prev : 0));
+            setError(prev => (prev ? null : prev));
+            setLoading(false);
+            cleanup();
+            return cleanup;
+        }
+
+        if (roundChanged || initDataChanged) {
+            setError(prev => (prev ? null : prev));
+        }
+
         const fetchOnce = async () => {
             try {
                 inFlight?.abort();
                 inFlight = new AbortController();
+                if (!hasFetchedRef.current) {
+                    setLoading(true);
+                }
                 const url = `https://${host}/api/game/${roundId}/bets-now`;
                 const res = await fetch(url, {
                     method: "POST",
@@ -67,33 +158,33 @@ export function useBetsNow(roundId?: number | null, initData?: string) {
                 });
                 if (!res.ok) throw new Error(`bets-now ${res.status}`);
                 const json = await res.json();
-                const nextTotal = extractBets(json).length;
-                if (!aborted && totalRef.current !== nextTotal) {
-                    totalRef.current = nextTotal;
-                    setTotalBets(nextTotal);
-                }
+                const parsedBets = extractBets(json)
+                    .filter(isRoundBet)
+                    .map(bet => ({ ...bet }));
+                const nextTotal = parsedBets.length;
                 if (!aborted) {
+                    if (totalRef.current !== nextTotal) {
+                        totalRef.current = nextTotal;
+                        setTotalBets(nextTotal);
+                    }
+                    setBets(prev => (areBetsEqual(prev, parsedBets) ? prev : parsedBets));
                     setError(prev => (prev ? null : prev));
                 }
             } catch (e) {
                 if (!aborted) setError(e as Error);
+            } finally {
+                if (!aborted) {
+                    hasFetchedRef.current = true;
+                    setLoading(false);
+                }
             }
         };
-        fetchOnce();
-        if (intervalRef.current) {
-            clearInterval(intervalRef.current);
-            intervalRef.current = null;
-        }
-        intervalRef.current = setInterval(fetchOnce, 3000);
-        return () => {
-            aborted = true;
-            inFlight?.abort();
-            if (intervalRef.current) {
-                clearInterval(intervalRef.current);
-                intervalRef.current = null;
-            }
-        };
-    }, [host, roundId, initData]);
 
-    return { bets: EMPTY_BETS, totalBets, loading: false, error };
+        fetchOnce();
+        stopInterval();
+        intervalRef.current = setInterval(fetchOnce, 3000);
+        return cleanup;
+    }, [host, roundId, initData, enabled]);
+
+    return { bets, totalBets, loading, error };
 }

--- a/src/shared/hooks/useBetsNowMock.ts
+++ b/src/shared/hooks/useBetsNowMock.ts
@@ -5,35 +5,102 @@ import type { RoundBet } from "./useBetsNow";
 
 const EMPTY_BETS: RoundBet[] = [];
 
-export function useBetsNowMock(roundId?: number | null, initData?: string) {
+const MOCK_USERS = [
+    { userId: 101001, usernameMasked: "Игрок •••1001", avatarUrl: "/profile/placeholder.png" },
+    { userId: 102002, usernameMasked: "Игрок •••2002", avatarUrl: "/profile/placeholder.png" },
+    { userId: 103003, usernameMasked: "Игрок •••3003", avatarUrl: "/profile/placeholder.png" },
+    { userId: 104004, usernameMasked: "Игрок •••4004", avatarUrl: "/profile/placeholder.png" },
+    { userId: 105005, usernameMasked: "Игрок •••5005", avatarUrl: "/profile/placeholder.png" },
+];
+
+type UseBetsNowMockOptions = {
+    enabled?: boolean;
+};
+
+export function useBetsNowMock(roundId?: number | null, initData?: string, options?: UseBetsNowMockOptions) {
+    const [bets, setBets] = useState<RoundBet[]>(EMPTY_BETS);
     const [totalBets, setTotalBets] = useState(0);
+    const [loading, setLoading] = useState(false);
     const error: Error | null = null;
 
     const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+    const betIdRef = useRef(1);
+    const lastRoundRef = useRef<number | null>(null);
+    const lastInitDataRef = useRef<string | null>(null);
+    const enabled = options?.enabled ?? true;
 
     useEffect(() => {
-        if (intervalRef.current) {
-            clearInterval(intervalRef.current);
-            intervalRef.current = null;
-        }
-
-        if (!roundId || !initData) {
-            setTotalBets(0);
-            return;
-        }
-
-        setTotalBets(0);
-        intervalRef.current = setInterval(() => {
-            setTotalBets(prev => prev + 1 + Math.floor(Math.random() * 3));
-        }, 1000);
-
-        return () => {
+        const stopInterval = () => {
             if (intervalRef.current) {
                 clearInterval(intervalRef.current);
                 intervalRef.current = null;
             }
         };
-    }, [roundId, initData]);
 
-    return { bets: EMPTY_BETS, totalBets, loading: false, error };
+        stopInterval();
+
+        const currentRoundId = roundId ?? null;
+        const currentInitData = initData ?? null;
+        const roundChanged = currentRoundId !== lastRoundRef.current;
+        const initChanged = currentInitData !== lastInitDataRef.current;
+
+        if (roundChanged) {
+            lastRoundRef.current = currentRoundId;
+        }
+        if (initChanged) {
+            lastInitDataRef.current = currentInitData;
+        }
+        if (roundChanged || initChanged) {
+            betIdRef.current = 1;
+            setBets(EMPTY_BETS);
+            setTotalBets(0);
+        }
+
+        if (!enabled) {
+            setLoading(false);
+            return stopInterval;
+        }
+
+        if (!roundId || !initData) {
+            setLoading(false);
+            setBets(EMPTY_BETS);
+            setTotalBets(0);
+            return stopInterval;
+        }
+
+        const createMockBet = (): RoundBet => {
+            const user = MOCK_USERS[Math.floor(Math.random() * MOCK_USERS.length)];
+            const amount = 5 + Math.floor(Math.random() * 95);
+            const multiplier = Number((1 + Math.random() * 4).toFixed(2));
+            return {
+                betId: betIdRef.current++,
+                userId: user.userId,
+                amount,
+                multiplier,
+                status: "accepted",
+                timestamp: new Date().toISOString(),
+                usernameMasked: user.usernameMasked,
+                avatarUrl: user.avatarUrl,
+            };
+        };
+
+        setLoading(true);
+        const initialBets = Array.from({ length: 8 }, createMockBet);
+        setBets(initialBets);
+        setTotalBets(initialBets.length);
+        setLoading(false);
+
+        intervalRef.current = setInterval(() => {
+            setBets(prev => {
+                const nextBet = createMockBet();
+                const nextBets = [nextBet, ...prev].slice(0, 50);
+                setTotalBets(prevTotal => prevTotal + 1);
+                return nextBets;
+            });
+        }, 2000);
+
+        return stopInterval;
+    }, [roundId, initData, enabled]);
+
+    return { bets, totalBets, loading, error };
 }


### PR DESCRIPTION
## Summary
- restore the players list to render current round bets with usernames, avatars, and empty state messaging
- extend the live bets hook to manage bet data and loading state while respecting the polling toggle
- update the mock bets hook to mirror the live hook by returning sample bet entries

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fd7755e31c8331a85831b2301379e7