### PR TITLE
Stop polling bets-now API during running rounds

### DIFF
--- a/src/feature/players-list/conteiner/players-list.tsx
+++ b/src/feature/players-list/conteiner/players-list.tsx
@@ -14,7 +14,9 @@ export function PlayersList() {
     const roundId = state?.roundId ?? null;
     const initData = user?.initData ?? "";
     const useMock = process.env.NEXT_PUBLIC_USE_MOCK_BETS === "1";
-    const { bets, totalBets, loading, error } = (useMock ? useBetsNowMock : useBetsNowReal)(roundId, initData);
+    const { bets, totalBets, loading, error } = (useMock ? useBetsNowMock : useBetsNowReal)(roundId, initData, {
+        phase: state?.phase,
+    });
 
     return (
         <div className="space-y-3 mb-6">


### PR DESCRIPTION
## Summary
- pass the current game phase into the bets hook
- skip bets-now polling while the round phase is running
- mirror the phase handling in the mock bets hook

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68fd845311d8833184acaedc04043276